### PR TITLE
Example showing how to subscribe to Patriot events

### DIFF
--- a/Photon/IoTlib/examples/myEventHandler/myEventHandler.ino
+++ b/Photon/IoTlib/examples/myEventHandler/myEventHandler.ino
@@ -1,0 +1,61 @@
+/*******************************************************
+Custom Event Handler example
+
+This example demonstrates how to subscribe to Patriot events.
+It allows you to respond to Alexa device commands.
+
+It is based on the starter example with behaviors removed.
+
+http://www.github.com/rlisle/Patriot
+
+Written by Ron Lisle
+
+BSD license, check LICENSE for more information.
+All text above must be included in any redistribution.
+
+Changelog:
+2017-10-30: Initial creation based on starter example.
+********************************************************/
+
+#include <IoT.h>
+#include <PatriotLight.h>
+
+extern String publishNameVariable;
+
+IoT *iot;
+
+void myEventHandler(const char *eventName, const char *rawData)
+{
+    // Convert arguments to Strings because their easier to work with
+    String data(rawData);
+    String event(eventName);
+    Serial.println("myEventHandler received event: " + event + ", data: " + data);
+
+    // Split "event:percent" formatted data into name & percent components
+    int colonPosition = data.indexOf(':');
+    String name = data.substring(0,colonPosition);
+    String percent = data.substring(colonPosition+1);
+    Serial.println("myEventHandler event name: " + name + ", percent: " + percent);
+}
+
+void setup()
+{
+    // Example of how to receive events to do your own processing
+    bool result = Particle.subscribe(publishNameVariable, myEventHandler, MY_DEVICES);
+    if(result == false)
+    {
+        Serial.println("Failed to subscribe to myEventHandler");
+    } else {
+        Serial.println("myEventHandler subscribe succeeded");
+    }
+
+    iot = IoT::getInstance();
+    iot->begin();
+
+    Light *led = new Light(D7, "Blue");
+    iot->addDevice(blue);
+}
+
+void loop() {
+    iot->loop();
+}

--- a/Photon/IoTlib/examples/myEventHandler/project.properties
+++ b/Photon/IoTlib/examples/myEventHandler/project.properties
@@ -1,0 +1,3 @@
+name=MyEventHandler
+dependencies.IoT=2.0.0
+dependencies.PatriotLight=2.0.0

--- a/Photon/IoTlib/examples/starter/starter.ino
+++ b/Photon/IoTlib/examples/starter/starter.ino
@@ -33,10 +33,12 @@ void setup() {
 
     // Create devices
     //Note: D7 is not a PWM pin, so it can only turn on or off
+    //      The last 4th argument specifies this.
+    //      The 3rd argument can be used to invert on/off.
     // Alexa will respond to "Alexa, turn L E D on" or "Alexa, turn off L E D"
     // You can change the name 'LED' to whatever you like, but it needs to be something
     // that Alexa can recognize.
-    Light *light1 = new Light(D7, "LED");
+    Light *light1 = new Light(D7, "LED", false, true);
 
     // Tell IoT about the devices you defined above
     iot->addDevice(light1);

--- a/Photon/IoTlib/src/IoT.h
+++ b/Photon/IoTlib/src/IoT.h
@@ -38,7 +38,7 @@ Changelog:
 class IoT {
 
     friend void globalSubscribeHandler(const char *eventName, const char *rawData);
-    friend void globalDhtHandler();
+//    friend void globalDhtHandler();
 
 public:
 


### PR DESCRIPTION
Add an example showing how a user can subscribe to the same events used by Patriot.
Note that custom handlers may not issue Particle publish calls or it will break Patriot's
event handling.