### PR TITLE
Add Smartthings Light device

### DIFF
--- a/Photon/IoTlib/src/IoT.cpp
+++ b/Photon/IoTlib/src/IoT.cpp
@@ -215,7 +215,8 @@ void IoT::connectMQTT(byte *brokerIP, String connectID, bool isBridge)
 
 void IoT::mqttPublish(String topic, String message)
 {
-    _mqtt->publish(topic, message);
+    String prefixedTopic = publishNameVariable + "/" + topic;
+    _mqtt->publish(prefixedTopic, message);
 }
 
 

--- a/Photon/IoTlib/src/IoT.cpp
+++ b/Photon/IoTlib/src/IoT.cpp
@@ -397,6 +397,14 @@ void IoT::mqttHandler(char* rawTopic, byte* payload, unsigned int length) {
             } else if(midTopic.equalsIgnoreCase("pong")) {
                 // Ignore it.
 
+            // RESET
+            } else if(midTopic.equalsIgnoreCase("reset")) {
+                // Respond if reset is addressed to us
+                if(rightTopic.equalsIgnoreCase(_controllerName)) {
+                    log("Reset addressed to us: "+_controllerName);
+                    reset();
+                }
+
             // LOG
             } else if(midTopic.equalsIgnoreCase("log")) {
                 // Ignore it.

--- a/Photon/IoTlib/src/IoT.cpp
+++ b/Photon/IoTlib/src/IoT.cpp
@@ -16,6 +16,7 @@ BSD license, check LICENSE for more information.
 All text above must be included in any redistribution.
 
 Changelog:
+2018-10-15: Expose MQTT publish.
 2018-09-04: Bridge Particle to MQTT
 2018-07-07: Convert MQTT format to match SmartThings
 2018-03-16: Add MQTT support
@@ -210,6 +211,11 @@ void IoT::connectMQTT(byte *brokerIP, String connectID, bool isBridge)
     } else {
         log("MQTT is NOT connected! Check MQTT IP address");
     }
+}
+
+void IoT::mqttPublish(String topic, String message)
+{
+    _mqtt->publish(topic, message);
 }
 
 

--- a/Photon/IoTlib/src/IoT.cpp
+++ b/Photon/IoTlib/src/IoT.cpp
@@ -213,12 +213,16 @@ void IoT::connectMQTT(byte *brokerIP, String connectID, bool isBridge)
     }
 }
 
-void IoT::mqttPublish(String topic, String message)
+void IoT::mqttRawPublish(String topic, String message)
+{
+    _mqtt->publish(topic, message);
+}
+
+void IoT::mqttPrefixedPublish(String topic, String message)
 {
     String prefixedTopic = publishNameVariable + "/" + topic;
     _mqtt->publish(prefixedTopic, message);
 }
-
 
 /**
  * Loop method must be called periodically,

--- a/Photon/IoTlib/src/IoT.h
+++ b/Photon/IoTlib/src/IoT.h
@@ -74,7 +74,8 @@ public:
      * Connect to an MQTT broker with specified IP
      **/
     void connectMQTT(byte *brokerIP, String connectID, bool isBridge = false);
-    void mqttPublish(String topic, String message);
+    void mqttRawPublish(String topic, String message);
+    void mqttPrefixedPublish(String topic, String message);
     
     /**
      * Loop needs to be called periodically

--- a/Photon/IoTlib/src/IoT.h
+++ b/Photon/IoTlib/src/IoT.h
@@ -16,6 +16,7 @@ BSD license, check LICENSE for more information.
 All text above must be included in any redistribution.
 
 Changelog:
+2018-10-15: Expose MQTT publish.
 2018-03-27: Add MQTT reconnect
 2018-01-17: Add functions for device state and type
 2017-10-22: Convert to scene-like behavior
@@ -73,7 +74,8 @@ public:
      * Connect to an MQTT broker with specified IP
      **/
     void connectMQTT(byte *brokerIP, String connectID, bool isBridge = false);
-
+    void mqttPublish(String topic, String message);
+    
     /**
      * Loop needs to be called periodically
      */

--- a/Photon/Plugins/STLight/LICENSE
+++ b/Photon/Plugins/STLight/LICENSE
@@ -1,0 +1,22 @@
+Copyright 2017 Ron Lisle
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+   disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+   products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Photon/Plugins/STLight/README.md
+++ b/Photon/Plugins/STLight/README.md
@@ -1,0 +1,71 @@
+# PatriotSTLight
+
+A Patriot plugin to support SmartThings lights.
+
+This library is used to support SmartThings lights.
+It requires that the SmartThings MQTT Bridge be installed and working.
+
+## Usage
+
+Include this library in any Photon sketch that needs to support
+SmartThings lights.
+
+
+```
+#include <IoT.h>
+#include <PatriotSTLight.h>
+
+IoT *iot;
+
+byte mqttServerIPAddress[] = {192.168.10.101};
+
+void setup() {
+    iot = IoT::getInstance();
+    iot->setControllerName("MyController");
+    iot->begin();
+    iot->connectMQTT(mqttServerIPAddress, "myController1");
+
+    // Create your device
+    STLight *deskLamp = new STLight("<SmartThingsName>", "<PatriotDeviceName>");
+
+    // Add it to IoT
+    iot->addDevice(deskLamp);
+
+    // Add any behaviors if appropriate
+    iot->addBehavior(new Behavior(deskLamp, "Work at desk", '>', 0, 100));
+    ...
+}
+
+void loop() {
+    iot->loop();
+}
+```
+
+## Documentation
+
+Refer to the Patriot Github repository and documentation for more
+information.
+
+
+## Contributing
+
+Here's how you can make changes to this library and eventually contribute those changes back.
+
+To get started, [clone the library from GitHub to your local machine](https://help.github.com/articles/cloning-a-repository/).
+
+Change the name of the library in `library.properties` to something different. You can add your name at then end.
+
+Modify the sources in <src> and <examples> with the new behavior.
+
+To compile an example, use `particle compile examples/usage` command in [Particle CLI](https://docs.particle.io/guide/tools-and-features/cli#update-your-device-remotely) or use our [Desktop IDE](https://docs.particle.io/guide/tools-and-features/dev/#compiling-code).
+
+After your changes are done you can upload them with `particle library upload` or `Upload` command in the IDE. This will create a private (only visible by you) library that you can use in other projects. Do `particle library add IoT_myname` to add the library to a project on your machine or add the IoT_myname library to a project on the Web IDE or Desktop IDE.
+
+At this point, you can create a [GitHub pull request](https://help.github.com/articles/about-pull-requests/) with your changes to the original library.
+
+If you wish to make your library public, use `particle library publish` or `Publish` command.
+
+## LICENSE
+Copyright 2018 Ron Lisle
+
+Refer to the included LICENSE file.

--- a/Photon/Plugins/STLight/examples/stlight/stlight.ino
+++ b/Photon/Plugins/STLight/examples/stlight/stlight.ino
@@ -1,0 +1,54 @@
+/*******************************************************
+STLights Example
+
+This example contains 3 Smartthings light bulbs
+    - Desk Lamp
+    - Kitchen Lamp
+    - Bedroom Lamp
+
+http://www.github.com/rlisle/Patriot
+
+Written by Ron Lisle
+
+BSD license, check LICENSE for more information.
+All text above must be included in any redistribution.
+
+Changelog:
+2018-10-15: Initial creation from modified copy of light.ino
+********************************************************/
+
+#include <IoT.h>
+#include <PatriotSTLight.h>
+
+IoT *iot;
+
+byte mqttServerIPAddress[] = {192.168.10.101};
+
+void setup() {
+    iot = IoT::getInstance();
+    iot->setControllerName("MyController");
+    iot->begin();
+    iot->connectMQTT(mqttServerIPAddress, "myController1");
+
+    // Create your devices
+    STLight *deskLamp = new STLight("Desk Lamp", "Desk Lamp");
+    STLight *kitchenLamp = new STLight("Kitchen Lamp", "Kitchen Lamp");
+    STLight *bedroomLamp = new STLight("Bedroom Lamp", "Bedroom Lamp");
+
+    // Add them to IoT
+    iot->addDevice(deskLamp);
+    iot->addDevice(kitchenLamp);
+    iot->addDevice(bedroomLamp);
+
+    // Add any behaviors if appropriate
+    iot->addBehavior(new Behavior(deskLamp, "Desk Work", '>', 0, 100));
+    iot->addBehavior(new Behavior(deskLamp, "Desk Work", '=', 0, 0));
+    iot->addBehavior(new Behavior(kitchenLamp, "Cook", '>', 0, 100));
+    iot->addBehavior(new Behavior(kitchenLamp, "Cook", '=', 0, 0));
+    iot->addBehavior(new Behavior(deskLamp, "Read", '>', 0, 100));
+    iot->addBehavior(new Behavior(deskLamp, "Read", '=', 0, 0));
+}
+
+void loop() {
+    iot->loop();
+}

--- a/Photon/Plugins/STLight/library.properties
+++ b/Photon/Plugins/STLight/library.properties
@@ -1,0 +1,9 @@
+name=STLight
+version=2.1.0
+author=Ron Lisle
+license=BSD
+sentence=Extend Patriot IoT to support Smartthings lights.
+paragraph=Patriot provides support for controlling IoT devices using Alexa and iOS devices. This plugin adds support for Smartthings dimmable lights. It requires that the smartthings-mqtt-bridge be installed and running.
+url=http://www.github.com/rlisle/Patriot
+repository=http://www.github.com/rlisle/Patriot
+architectures=particle-photon

--- a/Photon/Plugins/STLight/src/PatriotSTLight.cpp
+++ b/Photon/Plugins/STLight/src/PatriotSTLight.cpp
@@ -75,7 +75,7 @@ void Light::changePercent(int percent) {
     _targetPercent = percent;
     if(_dimmingDuration == 0.0 || isDimmingSupported() == false) {
         _currentPercent = percent;
-        outputPWM();
+        outputPercent();
 
     } else {
         startSmoothDimming();
@@ -201,11 +201,18 @@ void Light::loop()
  * Set the output percent value (0-100)
  */
 void Light::outputPercent() {
+    IoT *iot = IoT::getInstance();
+    String topic = stname;
     if(isDimmingSupported()) {
-        //TODO: Write _currentPercent to MQTT
+        //TODO: Write switch on/off first time only
+
+        topic += "/level";
+        iot->mqttPublish(topic, message);
     } else {
         bool isOn = _currentPercent > 49;
-        //TODO: Write isOn to MQTT
+        topic += "/switch";
+        String message = isOn ? "on" : "off";
+        iot->mqttPublish(topic, message);
     }
 }
 

--- a/Photon/Plugins/STLight/src/PatriotSTLight.cpp
+++ b/Photon/Plugins/STLight/src/PatriotSTLight.cpp
@@ -220,11 +220,11 @@ void STLight::outputPercent() {
 
         message = String::format("%d",_currentPercent);
         topic += "/level";
-        iot->mqttPublish(topic, message);
+        iot->mqttRawPublish(topic, message);
     } else {
         bool isOn = _currentPercent > 49;
         topic += "/switch";
         message = isOn ? "on" : "off";
-        iot->mqttPublish(topic, message);
+        iot->mqttRawPublish(topic, message);
     }
 }

--- a/Photon/Plugins/STLight/src/PatriotSTLight.cpp
+++ b/Photon/Plugins/STLight/src/PatriotSTLight.cpp
@@ -213,7 +213,7 @@ void STLight::loop()
  */
 void STLight::outputPercent() {
     IoT *iot = IoT::getInstance();
-    String topic = _stname;
+    String topic = "smartthings/"+_stname;
     String message;
     if(isDimmingSupported()) {
         //TODO: Write switch on/off first time only

--- a/Photon/Plugins/STLight/src/PatriotSTLight.cpp
+++ b/Photon/Plugins/STLight/src/PatriotSTLight.cpp
@@ -1,0 +1,220 @@
+/******************************************************************
+ Smartthings light LED dimming control
+
+ Features:
+ - On/Off control
+ - Smooth dimming with duration
+
+ http://www.github.com/rlisle/Patriot
+
+ Written by Ron Lisle
+
+ BSD license, check license.txt for more information.
+ All text above must be included in any redistribution.
+
+ Datasheets:
+
+ Changelog:
+ 2018-10-15: Initial version
+ ******************************************************************/
+
+#include "PatriotSTLight.h"
+
+/**
+ * Constructor
+ * @param stname String name used defined by Smartthings.
+ * @param name String name used to address the light by Alexa & Patriot.
+ * @param forceDigital True if output On/Off only
+ */
+STLight::STLight(String stname, String name, bool forceDigital)
+        : _stname(stname),
+          Device(name, DeviceType::Light),
+          _forceDigital(forceDigital)
+{
+    _dimmingPercent           = 100;                                // On full
+    _dimmingDuration          = 2.0;
+    _currentPercent           = 0.0;
+    _targetPercent            = 0;
+    _incrementPerMillisecond  = 0.0;
+    _lastUpdateTime           = 0;
+    _commandPercent            = 0;
+}
+
+/**
+ * Set percent
+ * @param percent Int 0 to 100
+ */
+void Light::setPercent(int percent) {
+    _commandPercent = percent;
+    changePercent(percent);
+}
+
+/**
+ * Get percent
+ * @return Int current 0-100 percent value
+ */
+int Light::getPercent() {
+    return _currentPercent;
+}
+
+/**
+ * Set On
+ */
+void Light::setOn() {
+    if(isAlreadyOn()) return;
+    changePercent(_dimmingPercent);
+}
+
+/**
+ * Change percent
+ * @param percent Int new percent value
+ */
+void Light::changePercent(int percent) {
+    if(_targetPercent == percent) return;
+
+    _targetPercent = percent;
+    if(_dimmingDuration == 0.0 || isDimmingSupported() == false) {
+        _currentPercent = percent;
+        outputPWM();
+
+    } else {
+        startSmoothDimming();
+    }
+}
+
+/**
+ * Is already on?
+ * @return bool true if light is on
+ */
+bool Light::isAlreadyOn() {
+    return _targetPercent == _dimmingPercent;
+}
+
+/**
+ * Is already off?
+ * @return bool true if light is off
+ */
+bool Light::isAlreadyOff() {
+    return _targetPercent == 0;
+}
+
+/**
+ * Start smooth dimming
+ */
+void Light::startSmoothDimming() {
+    if((int)_currentPercent != _targetPercent){
+        _lastUpdateTime = millis();
+        float delta = _targetPercent - _currentPercent;
+        _incrementPerMillisecond = delta / (_dimmingDuration * 1000);
+    }
+}
+
+/**
+ * Set light off
+ */
+void Light::setOff() {
+    if(isAlreadyOff()) return;
+    setPercent(0);
+}
+
+/**
+ * Is light on?
+ * @return bool true if light is on
+ */
+bool Light::isOn() {
+    return !isOff();
+}
+
+/**
+ * Is light off?
+ * @return bool true if light is off
+ */
+bool Light::isOff() {
+    return _targetPercent == 0;
+}
+
+/**
+ * Set dimming percent
+ * @param percent Int new percent value
+ */
+void Light::setDimmingPercent(int percent) {
+    if(_dimmingPercent != percent){
+        _dimmingPercent = percent;
+        changePercent(percent);
+    }
+}
+
+/**
+ * Get dimming percent
+ * @return Int current dimming percent value
+ */
+int Light::getDimmingPercent() {
+    return _dimmingPercent;
+}
+
+/**
+ * Set dimming duration
+ * @param duration float number of seconds
+ */
+void Light::setDimmingDuration(float duration) {
+    _dimmingDuration = duration;
+}
+
+/**
+ * Get dimming duration
+ * @return float number of dimming duration seconds
+ */
+float Light::getDimmingDuration() {
+    return _dimmingDuration;
+}
+
+/**
+ * Private Methods
+ */
+
+/**
+ * loop()
+ */
+void Light::loop()
+{
+    if(_currentPercent == _targetPercent) {
+        return;
+    }
+
+    long loopTime = millis();
+    float millisSinceLastUpdate = (loopTime - _lastUpdateTime);
+    _currentPercent += _incrementPerMillisecond * millisSinceLastUpdate;
+    if(_incrementPerMillisecond > 0) {
+        if(_currentPercent > _targetPercent) {
+            _currentPercent = _targetPercent;
+        }
+    } else {
+        if(_currentPercent < _targetPercent) {
+            _currentPercent = _targetPercent;
+        }
+    }
+    _lastUpdateTime = loopTime;
+    outputPercent();
+};
+
+/**
+ * Set the output percent value (0-100)
+ */
+void Light::outputPercent() {
+    if(isDimmingSupported()) {
+        //TODO: Write _currentPercent to MQTT
+    } else {
+        bool isOn = _currentPercent > 49;
+        //TODO: Write isOn to MQTT
+    }
+}
+
+/**
+ * Is Dimming supported?
+ * @return bool device supports dimming
+ */
+bool Light::isDimmingSupported()
+{
+    //TODO: query device
+    return true;
+}

--- a/Photon/Plugins/STLight/src/PatriotSTLight.h
+++ b/Photon/Plugins/STLight/src/PatriotSTLight.h
@@ -40,6 +40,8 @@ class STLight : public Device
     bool      isAlreadyOff();
     void      changePercent(int percent);
     void      startSmoothDimming();
+    bool      isDimmingSupported();
+    void      outputPercent();
 
  public:
     STLight(String stname, String name, bool forceDigital=false);

--- a/Photon/Plugins/STLight/src/PatriotSTLight.h
+++ b/Photon/Plugins/STLight/src/PatriotSTLight.h
@@ -1,0 +1,60 @@
+/******************************************************************
+ Smartthings light dimming control
+
+ Features:
+ - On/Off control
+ - Smooth dimming with duration
+
+ http://www.github.com/rlisle/Patriot
+
+ Written by Ron Lisle
+
+ BSD license, check license.txt for more information.
+ All text above must be included in any redistribution.
+
+ Datasheets:
+
+ Changelog:
+ 2018-10-15: Initial version
+ ******************************************************************/
+
+#pragma once
+
+#include "Particle.h"
+#include "device.h"
+
+class STLight : public Device
+{
+ private:
+    String    _stname;                  // Smartthings device name
+    int       _dimmingPercent;
+    float     _dimmingDuration;
+    float     _currentPercent;
+    int       _targetPercent;
+    int       _commandPercent;
+    float     _incrementPerMillisecond;
+    long      _lastUpdateTime;
+    bool      _forceDigital;            // On/Off only
+
+    bool      isAlreadyOn();
+    bool      isAlreadyOff();
+    void      changePercent(int percent);
+    void      startSmoothDimming();
+
+ public:
+    STLight(String stname, String name, bool forceDigital=false);
+
+    void      setPercent(int percent);
+    int       getPercent();
+    void      setOn();
+    void      setOff();
+    bool      isOn();
+    bool      isOff();
+
+    void      setDimmingPercent(int percent);
+    void      setDimmingDuration(float duration);
+    int       getDimmingPercent();
+    float     getDimmingDuration();
+
+    void      loop();
+};

--- a/Photon/Plugins/STLight/src/device.h
+++ b/Photon/Plugins/STLight/src/device.h
@@ -1,0 +1,1 @@
+../../../IoTlib/src/device.h


### PR DESCRIPTION
Create a new plugin to control Smartthings lights.
A Patriot device is created that will bridge on/off requests to Smartthings via MQTT.
Also adding a reset function to IoT.