### PR TITLE
Remove using retained

### DIFF
--- a/Photon/Controllers/FrontPanel/src/FrontPanel.ino
+++ b/Photon/Controllers/FrontPanel/src/FrontPanel.ino
@@ -74,19 +74,20 @@ String mqttServer = "192.168.10.184";
 
 IoT *iot;
 
-//retained NCD8Relay kitchenSink(ADDRESS1, NUMRELAYS, 0, "Sink");
-retained NCD8Relay frontAwning(ADDRESS1, NUMRELAYS, 1, "FrontAwning");
-retained NCD8Relay rightTrim(ADDRESS1, NUMRELAYS, 2, "RightTrim");
-retained NCD8Relay leftTrim(ADDRESS1, NUMRELAYS, 3, "LeftTrim");
-//retained NCD8Relay ceiling(ADDRESS1, NUMRELAYS, 4, "Ceiling");
-retained NCD8Relay dsFloods(ADDRESS1, NUMRELAYS, 5, "DoorSide");
-retained NCD8Relay osFloods(ADDRESS1, NUMRELAYS, 6, "OtherSide");
-retained NCD8Relay frontPorch(ADDRESS1, NUMRELAYS, 7, "FrontPorch");
+// To use persistent storage, insert "retained" before NCD8Relay
+//NCD8Relay kitchenSink(ADDRESS1, NUMRELAYS, 0, "Sink");
+NCD8Relay frontAwning(ADDRESS1, NUMRELAYS, 1, "FrontAwning");
+NCD8Relay rightTrim(ADDRESS1, NUMRELAYS, 2, "RightTrim");
+NCD8Relay leftTrim(ADDRESS1, NUMRELAYS, 3, "LeftTrim");
+//NCD8Relay ceiling(ADDRESS1, NUMRELAYS, 4, "Ceiling");
+NCD8Relay dsFloods(ADDRESS1, NUMRELAYS, 5, "DoorSide");
+NCD8Relay osFloods(ADDRESS1, NUMRELAYS, 6, "OtherSide");
+NCD8Relay frontPorch(ADDRESS1, NUMRELAYS, 7, "FrontPorch");
 
-retained NCD8Light ceiling(ADDRESS2, 0, "Ceiling", 2);
-retained NCD8Light kitchenCeiling(ADDRESS2, 1, "kitchenCeiling", 2);
-retained NCD8Light kitchenSink(ADDRESS2, 2, "Sink", 2);
-retained NCD8Light kitchenCabinets(ADDRESS2, 3, "Cabinets", 2);
+NCD8Light ceiling(ADDRESS2, 0, "Ceiling", 2);
+NCD8Light kitchenCeiling(ADDRESS2, 1, "kitchenCeiling", 2);
+NCD8Light kitchenSink(ADDRESS2, 2, "Sink", 2);
+NCD8Light kitchenCabinets(ADDRESS2, 3, "Cabinets", 2);
 
 void setup() {
     iot = IoT::getInstance();

--- a/Photon/Controllers/LeftSlide/src/LeftSlide.ino
+++ b/Photon/Controllers/LeftSlide/src/LeftSlide.ino
@@ -42,8 +42,9 @@ IoT *iot;
 String mqttServer = "192.168.1.10";
 
 // Use Backup SRAM to persist led state between resets
-retained Light couch(TX, "Couch");
-retained Light vertical(RX, "LeftVertical");
+// To use persistent storage, insert "retained" before Light
+Light couch(TX, "Couch");
+Light vertical(RX, "LeftVertical");
 
 void setup() {
   iot = IoT::getInstance();

--- a/Photon/Controllers/RearPanel/src/RearPanel.ino
+++ b/Photon/Controllers/RearPanel/src/RearPanel.ino
@@ -69,14 +69,15 @@ String mqttServer = "192.168.10.184";
 
 IoT *iot;
 
-retained NCD8Relay loft(ADDRESS1, NUMRELAYS, 4, "Loft");
-retained NCD8Relay rampAwning(ADDRESS1, NUMRELAYS, 2, "RampAwning");
-retained NCD8Relay rampPorch(ADDRESS1, NUMRELAYS, 3, "RampPorch");
-retained NCD8Relay rearAwning(ADDRESS1, NUMRELAYS, 0, "RearAwning");
-retained NCD8Relay rearPorch(ADDRESS1, NUMRELAYS, 1, "RearPorch");
+// To use persistent storage, insert "retained" before NCD8Relay
+NCD8Relay loft(ADDRESS1, NUMRELAYS, 4, "Loft");
+NCD8Relay rampAwning(ADDRESS1, NUMRELAYS, 2, "RampAwning");
+NCD8Relay rampPorch(ADDRESS1, NUMRELAYS, 3, "RampPorch");
+NCD8Relay rearAwning(ADDRESS1, NUMRELAYS, 0, "RearAwning");
+NCD8Relay rearPorch(ADDRESS1, NUMRELAYS, 1, "RearPorch");
 
-retained NCD8Light piano(ADDRESS2, 0, "Piano", 2);
-retained NCD8Light office(ADDRESS2, 1, "OfficeCeiling", 2);
+NCD8Light piano(ADDRESS2, 0, "Piano", 2);
+NCD8Light office(ADDRESS2, 1, "OfficeCeiling", 2);
 
 void setup() {
     iot = IoT::getInstance();

--- a/Photon/Controllers/RonTest/src/RonTest.ino
+++ b/Photon/Controllers/RonTest/src/RonTest.ino
@@ -36,15 +36,16 @@ String mqttServerIP = "192.168.10.184";
 IoT     *iot;
 
 // Use Backup SRAM to persist led state between resets
-//retained Light led(D7, "led", false, true);
-retained NCD8Light test1(1, 0, "test1", 0); // immediate
-retained NCD8Light test2(1, 1, "test2", 1); // 1 second transition
-retained NCD8Light test3(1, 2, "test3", 2); // 2 " "
-retained NCD8Light test4(1, 3, "test4", 3);
-retained NCD8Light test5(1, 4, "test5", 4);
-retained NCD8Light test6(1, 5, "test6", 5);
-retained NCD8Light test7(1, 6, "test7", 6);
-retained NCD8Light test8(1, 7, "test8", 7);
+// To use persistent storage, insert "retained" before NCD8Relay
+//Light led(D7, "led", false, true);
+NCD8Light test1(1, 0, "test1", 0); // immediate
+NCD8Light test2(1, 1, "test2", 1); // 1 second transition
+NCD8Light test3(1, 2, "test3", 2); // 2 " "
+NCD8Light test4(1, 3, "test4", 3);
+NCD8Light test5(1, 4, "test5", 4);
+NCD8Light test6(1, 5, "test6", 5);
+NCD8Light test7(1, 6, "test7", 6);
+NCD8Light test8(1, 7, "test8", 7);
 
 void setup() {
   iot = IoT::getInstance();

--- a/Photon/Plugins/NCD8Light/src/PatriotNCD8Light.cpp
+++ b/Photon/Plugins/NCD8Light/src/PatriotNCD8Light.cpp
@@ -38,7 +38,8 @@ NCD8Light::NCD8Light(int8_t address, int8_t lightNum, String name, int8_t durati
     : Device(name, DeviceType::NCD8Light)
 {
     _lightNum   = lightNum;
-    // _percent is left uninitialized to pickup state from SRAM
+    // _percent is left uninitialized if retained storage is used to pickup state from SRAM
+    _percent = 0;
     _currentPercent = _percent;
     _brightness = 100;      // Default to 100
     _dimmingDuration = 2.0; // Default to 2 seconds

--- a/Photon/Plugins/NCD8Relay/src/PatriotNCD8Relay.cpp
+++ b/Photon/Plugins/NCD8Relay/src/PatriotNCD8Relay.cpp
@@ -45,7 +45,8 @@ NCD8Relay::NCD8Relay(int8_t address, int8_t numRelays, int8_t relayNum, String n
     : Device(name, DeviceType::NCD8Relay)
 {
     _relayNum   = relayNum;
-    // _percent is left uninitialized to pickup state from SRAM
+    // _percent is left uninitialized if retained storage is used to pickup state from SRAM
+    _percent = 0;
     _duration   = duration;
     _stopMillis = 0;
 


### PR DESCRIPTION
Remove use of "retained" persistent storage. Sometimes the code hangs, or the MQTT server and internet stop working, and lights get stuck in the On state. The only way to shut them off is to pull the fuse to the controller unless persistent storage is used, in which case the lights come back on when power is reapplied (as designed). Prefer to be able to shut off lights in this case.