### PR TITLE
Noqos

### DIFF
--- a/Photon/IoTlib/src/IoT.cpp
+++ b/Photon/IoTlib/src/IoT.cpp
@@ -61,11 +61,6 @@ void globalMQTTHandler(char *topic, byte* payload, unsigned int length) {
     iot->mqttHandler(topic, payload, length);
 }
 
-void globalQOScallback(unsigned int data) {
-    IoT* iot = IoT::getInstance();
-    iot->mqttQOSHandler(data);
-}
-
 void globalLog(String message) {
     IoT* iot = IoT::getInstance();
     iot->log(message);
@@ -236,11 +231,5 @@ void IoT::mqttHandler(char* rawTopic, byte* payload, unsigned int length) {
 
     if(_mqttManager != NULL) {
         _mqttManager->mqttHandler(rawTopic, payload, length);
-    }
-}
-
-void IoT::mqttQOSHandler(unsigned int data) {
-    if(_mqttManager != NULL) {
-        _mqttManager->mqttQOSHandler(data);
     }
 }

--- a/Photon/IoTlib/src/IoT.h
+++ b/Photon/IoTlib/src/IoT.h
@@ -49,7 +49,6 @@ class IoT {
 
     friend void globalSubscribeHandler(const char *eventName, const char *rawData);
     friend void globalMQTTHandler(char *topic, byte* payload, unsigned int length);
-    friend void globalQOScallback(unsigned int data);
 
 public:
 
@@ -117,5 +116,4 @@ private:
     void periodicReset();
 
     void mqttHandler(char* topic, byte* payload, unsigned int length);
-    void mqttQOSHandler(unsigned int data);
 };

--- a/Photon/IoTlib/src/MQTTManager.cpp
+++ b/Photon/IoTlib/src/MQTTManager.cpp
@@ -23,18 +23,16 @@ extern void globalMQTTHandler(char *topic, byte* payload, unsigned int length);
 
 MQTTManager::MQTTManager(String brokerIP, String connectID, String controllerName, Devices *devices)
 {
-    _brokerIP = brokerIP;       // delete?
-    _connectID = connectID;     // delete?
     _controllerName = controllerName;
     _devices = devices;
     
     _states = new States();
 
     _mqtt =  new MQTT((char *)brokerIP.c_str(), 1883, globalMQTTHandler);
-    connect();
+    connect(connectID);
 }
 
-void MQTTManager::connect() {
+void MQTTManager::connect(String connectID) {
 
     _lastMQTTtime = Time.now();
 
@@ -47,7 +45,7 @@ void MQTTManager::connect() {
         _mqtt->disconnect();
     }
 
-    _mqtt->connect(_connectID);  
+    _mqtt->connect(connectID);  
     if (_mqtt->isConnected()) {
         if(_mqtt->subscribe(kPublishName+"/#") == false) {
             log("Unable to subscribe to MQTT " + kPublishName + "/#");

--- a/Photon/IoTlib/src/MQTTManager.cpp
+++ b/Photon/IoTlib/src/MQTTManager.cpp
@@ -45,7 +45,7 @@ void MQTTManager::connect(String connectID) {
         _mqtt->disconnect();
     }
 
-    _mqtt->connect(connectID);  
+    _mqtt->connect(connectID);
     if (_mqtt->isConnected()) {
         if(_mqtt->subscribe(kPublishName+"/#") == false) {
             log("Unable to subscribe to MQTT " + kPublishName + "/#");
@@ -108,7 +108,7 @@ void MQTTManager::parseMessage(String topic, String message)
     
     // New Protocol: patriot/<name>  <value>
     if(topic.startsWith(kPublishName+"/")) {
-        log("parsing t:" + topic + ", m:" + message);
+        //log("parsing t:" + topic + ", m:" + message);
         String subtopic = topic.substring(kPublishName.length()+1);
         
         // Look for reserved names
@@ -147,7 +147,7 @@ void MQTTManager::parseMessage(String topic, String message)
         } else {
             
             int percent = parseValue(message);
-            log("Parser setting state " + subtopic + " to " + message);
+            //log("Parser setting state " + subtopic + " to " + message);
             _states->addState(subtopic,percent);
             _devices->stateDidChange(_states);
         }

--- a/Photon/IoTlib/src/MQTTManager.cpp
+++ b/Photon/IoTlib/src/MQTTManager.cpp
@@ -20,7 +20,6 @@ Changelog:
 #include "constants.h"
 
 extern void globalMQTTHandler(char *topic, byte* payload, unsigned int length);
-extern void globalQOScallback(unsigned int);
 
 MQTTManager::MQTTManager(String brokerIP, String connectID, String controllerName, Devices *devices)
 {
@@ -50,8 +49,6 @@ void MQTTManager::connect() {
 
     _mqtt->connect(_connectID);  
     if (_mqtt->isConnected()) {
-        _mqtt->addQosCallback(globalQOScallback);
-
         if(_mqtt->subscribe(kPublishName+"/#") == false) {
             log("Unable to subscribe to MQTT " + kPublishName + "/#");
         }
@@ -102,11 +99,6 @@ void MQTTManager::mqttHandler(char* rawTopic, byte* payload, unsigned int length
     _lastMQTTtime = Time.now();
 
     parseMessage(topic.toLowerCase(), message.toLowerCase());
-}
-
-void MQTTManager::mqttQOSHandler(unsigned int data) {
-
-    log("QOS callback: " + String(data));
 }
 
 //Mark - Parser

--- a/Photon/IoTlib/src/MQTTManager.h
+++ b/Photon/IoTlib/src/MQTTManager.h
@@ -35,7 +35,6 @@ public:
     void        parseMessage(String topic, String message);
     void        loop();
     void        mqttHandler(char* topic, byte* payload, unsigned int length);
-    void        mqttQOSHandler(unsigned int data);
     
     void        log(String message);
     

--- a/Photon/IoTlib/src/MQTTManager.h
+++ b/Photon/IoTlib/src/MQTTManager.h
@@ -40,8 +40,6 @@ public:
     
 private:
     MQTT      *_mqtt;
-    String    _connectID;
-    String    _brokerIP;
     String    _controllerName;
     system_tick_t _lastMQTTtime;
     
@@ -49,7 +47,7 @@ private:
     Devices   *_devices;
     
     void      (*_callback)(char*,uint8_t*,unsigned int);
-    void      connect();
+    void      connect(String connectID);
     void      reconnectCheck();
     int       parseValue(String message);
 };

--- a/Photon/Plugins/NCD8Light/src/PatriotNCD8Light.cpp
+++ b/Photon/Plugins/NCD8Light/src/PatriotNCD8Light.cpp
@@ -93,7 +93,7 @@ int8_t NCD8Light::initializeBoard() {
  * @param percent Int 0 to 100.
  */
 void NCD8Light::setPercent(int percent) {
-    Serial.println("Dimmer " + String(_name) + " setPercent " + String(percent));
+    //Serial.println("Dimmer " + String(_name) + " setPercent " + String(percent));
     _targetPercent = percent;
     if(_dimmingDuration == 0.0) {
         _percent = percent;


### PR DESCRIPTION
Remove unused MQTT QOS code.
Remove 2 unused MQTT member variables: brokerIP and connectID.
Cleanup extraneous logging.